### PR TITLE
Fixed empty strap strip issue

### DIFF
--- a/Essay_Analysis_Tool/MainForm.cs
+++ b/Essay_Analysis_Tool/MainForm.cs
@@ -309,6 +309,7 @@ namespace Essay_Analysis_Tool
                 }
                 tsFiles.RemoveTab(tab);
             }
+            SanitizeTabStrip();
         }
 
         /// <summary>
@@ -488,6 +489,7 @@ namespace Essay_Analysis_Tool
                 tsFiles.RemoveTab(tsFiles.SelectedItem);
                 UpdateDocumentMap();
             }
+            SanitizeTabStrip();
         }
 
         /// <summary>
@@ -1000,6 +1002,7 @@ namespace Essay_Analysis_Tool
         /// <param name="e">Event Arguments<see cref="EventArgs"/></param>
         private void TsFiles_TabStripItemClosed(object sender, EventArgs e)
         {
+            SanitizeTabStrip();
             UpdateDocumentMap();
         }
 
@@ -1048,6 +1051,15 @@ namespace Essay_Analysis_Tool
                         e.Cancel = true;
                         break;
                 }
+            }
+        }
+
+        private void SanitizeTabStrip()
+        {
+            List<FATabStripItem> list = GetTabList();
+            if (list.Count == 0)
+            {
+                CreateTab();
             }
         }
 

--- a/Essay_Analysis_Tool/changes.xml
+++ b/Essay_Analysis_Tool/changes.xml
@@ -3,6 +3,7 @@
   <body>
     <release date="${buildTimestamp}" description="" version="1.0.0">
       <action dev="" issue="" date="" type=""></action>
+      <action dev="Zachary Pedigo" issue="ISSUE-0064" date="08-03-2019" type="fix">Tab list should always contain at least one tab.</action>
       <action dev="Zachary Pedigo" issue="ISSUE-0067" date="08-03-2019" type="add">Added logger system to application and updated FastColoredTextBox.</action>
       <action dev="Zachary Pedigo" issue="ISSUE-0062" date="07-22-2019" type="add">Missing some Shortcuts.</action>
       <action dev="Zachary Pedigo" issue="ISSUE-0061" date="07-22-2019" type="add">Added about page.</action>


### PR DESCRIPTION
## Description
___
This commit resolves #64 
___
When a tab is closed using any of the three available methods for closing a tab or tabs, the tab strip bar is "sanitized", which essentially means we are verifying that there is at least one tab in the tabstrip or we create a new blank tab.