### PR TITLE
Implementing the ability to comment out selected lines

### DIFF
--- a/Essay_Analysis_Tool/MainForm.cs
+++ b/Essay_Analysis_Tool/MainForm.cs
@@ -826,16 +826,27 @@ namespace Essay_Analysis_Tool
                         CreateTab(file_open.FileName);
                     }
                 }
-                else if (e.KeyCode == Keys.S && e.Modifiers == Keys.Control && CurrentTB != null)
+                else if (e.KeyCode == Keys.S && e.Modifiers == Keys.Control)
                 {
                     if (tsFiles.SelectedItem != null)
                     {
                         Save(tsFiles.SelectedItem);
                     }
                 }
-                else if (e.Control && e.Shift && e.KeyCode == Keys.Back && CurrentTB != null)
+                else if (e.Control && e.Shift && e.KeyCode == Keys.L)
                 {
                     CurrentTB.ClearCurrentLine();
+                }
+                else if (e.Control && e.Shift && e.KeyCode == Keys.Oem2 && CurrentTB.CommentPrefix != null)
+                {
+                    if (!CurrentTB.SelectedText.Contains(CurrentTB.CommentPrefix))
+                    {
+                        CurrentTB.InsertLinePrefix(CurrentTB.CommentPrefix);
+                    }
+                    else
+                    {
+                        CurrentTB.RemoveLinePrefix(CurrentTB.CommentPrefix);
+                    }
                 }
             }
         }

--- a/Essay_Analysis_Tool/changes.xml
+++ b/Essay_Analysis_Tool/changes.xml
@@ -3,7 +3,8 @@
   <body>
     <release date="${buildTimestamp}" description="" version="1.0.0">
       <action dev="" issue="" date="" type=""></action>
-      <action dev="Zachary Pedigo" issue="ISSUE-0073" date="08-04-2019" type="fix">Remove Batch file and Java support.</action>
+      <action dev="Zachary Pedigo" issue="ISSUE-0076" date="08-12-2019" type="add">Implement the ability to comment selected lines.</action>
+      <action dev="Zachary Pedigo" issue="ISSUE-0073" date="08-11-2019" type="fix">Remove Batch file and Java support.</action>
       <action dev="Zachary Pedigo" issue="ISSUE-0063" date="08-11-2019" type="add">Save file button should be dithered while data is clean.</action>
       <action dev="Zachary Pedigo" issue="N/A" date="08-04-2019" type="fix">Minor UI Improvements and Bug Fixes.</action>
       <action dev="Zachary Pedigo" issue="ISSUE-0064" date="08-03-2019" type="fix">Tab list should always contain at least one tab.</action>


### PR DESCRIPTION
## Description
This commit resolves #76 
## Scope
This commit introduced the ability to comment out selected lines using the hotkey Ctrl+Shift+"/"