### PR TITLE
Fix app crash when clicking File/Open submenu after fresh start

### DIFF
--- a/Essay_Analysis_Tool/MainForm.cs
+++ b/Essay_Analysis_Tool/MainForm.cs
@@ -720,13 +720,16 @@ namespace Essay_Analysis_Tool
         }
 
         /// <summary>
-        /// The OpenToolStripMenuItem_Click
+        /// Handle when the 'Open' submenu clicked in the 'File' menu.
         /// </summary>
         /// <param name="sender">Sender Object<see cref="object"/></param>
         /// <param name="e">Event Arguments<see cref="EventArgs"/></param>
         private void OpenToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            CreateTab(file_open.FileName);
+            if(file_open.ShowDialog() == DialogResult.OK)
+            {
+                CreateTab(file_open.FileName);
+            }
         }
 
         /// <summary>

--- a/Essay_Analysis_Tool/changes.xml
+++ b/Essay_Analysis_Tool/changes.xml
@@ -3,6 +3,7 @@
   <body>
     <release date="${buildTimestamp}" description="" version="1.0.0">
       <action dev="" issue="" date="" type=""></action>
+      <action dev="Tom PoLáKoSz" issue="ISSUE-0089" date="08-29-2019" type="fix">App crashes when clicking File/Open submenu after fresh start.</action>
       <action dev="Zachary Pedigo" issue="ISSUE-0087" date="08-26-2019" type="fix">Duplicate files can be opened several times.</action>
       <action dev="Tom PoLáKoSz" issue="ISSUE-0081" date="08-21-2019" type="fix">Current editor language does not change on save.</action>
       <action dev="Zachary Pedigo" issue="ISSUE-0076" date="08-12-2019" type="add">Implement the ability to comment selected lines.</action>


### PR DESCRIPTION
Without the fix, the `file_open.FileName` would be string.Empty and the `SetCurrentEditorSyntaxHighlight` would throw an `System.IndexOutOfRangeException` because the `int token` would be -1.

Fixes #89