### PR TITLE
Fix #87 Duplicate files can be opened several times

### DIFF
--- a/Essay_Analysis_Tool/MainForm.cs
+++ b/Essay_Analysis_Tool/MainForm.cs
@@ -162,16 +162,20 @@ namespace Essay_Analysis_Tool
 
             tb.AddStyle(sameWordsStyle);
 
-            if (fileName != null)
-            {
-                SetCurrentEditorSyntaxHighlight(fileName, tb);
-                tb.OpenFile(fileName);
-            }
-
             var tab = new FATabStripItem(fileName != null ? Path.GetFileName(fileName) : "[new]", tb)
             {
                 Tag = fileName
             };
+
+            if (fileName != null && !IsFileAlreadyOpen(fileName))
+            {
+                SetCurrentEditorSyntaxHighlight(fileName, tb);
+                tb.OpenFile(fileName);
+            }
+            else if (fileName != null)
+            {
+                return;
+            }
 
             //create autocomplete popup menu
             popupMenu = new AutocompleteMenu(tb);
@@ -186,6 +190,19 @@ namespace Essay_Analysis_Tool
             tb.TextChangedDelayed += new EventHandler<TextChangedEventArgs>(Tb_TextChangedDelayed);
             UpdateDocumentMap();
             HighlightCurrentLine();
+        }
+
+        private bool IsFileAlreadyOpen(string fileName)
+        {
+            foreach (FATabStripItem tab in tsFiles.Items)
+            {
+                if (tab.Tag as string == fileName)
+                {
+                    tsFiles.SelectedItem = tab;
+                    return true;
+                }
+            }
+            return false;
         }
 
         private void CreateTab()

--- a/Essay_Analysis_Tool/changes.xml
+++ b/Essay_Analysis_Tool/changes.xml
@@ -3,6 +3,7 @@
   <body>
     <release date="${buildTimestamp}" description="" version="1.0.0">
       <action dev="" issue="" date="" type=""></action>
+      <action dev="Zachary Pedigo" issue="ISSUE-0087" date="08-26-2019" type="fix">Duplicate files can be opened several times.</action>
       <action dev="Tom PoLáKoSz" issue="ISSUE-0081" date="08-21-2019" type="fix">Current editor language does not change on save.</action>
       <action dev="Zachary Pedigo" issue="ISSUE-0076" date="08-12-2019" type="add">Implement the ability to comment selected lines.</action>
       <action dev="Zachary Pedigo" issue="ISSUE-0073" date="08-11-2019" type="fix">Remove Batch file and Java support.</action>


### PR DESCRIPTION
## Description
This commit resolves #87 

This commit introduces new functionality that checks if a filename/path exists in the editor before opening the file. If the file does already exist then that tab is selected, if not then the new file is opened and a new tab is created and selected.