### PR TITLE
Fixed issue with current tab behavior

### DIFF
--- a/Notepad-Sharp/MainForm.cs
+++ b/Notepad-Sharp/MainForm.cs
@@ -50,13 +50,7 @@ namespace NotepadSharp
         {
             get
             {
-                Form activeMdi = ActiveMdiChild;
-
-                if (activeMdi != null && activeMdi is Editor)
-                {
-                    return activeMdi as Editor;
-                }
-                return null;
+                return this.dockpanel.ActiveContent as Editor;
             }
         }
 

--- a/Notepad-Sharp/changes.xml
+++ b/Notepad-Sharp/changes.xml
@@ -2,6 +2,7 @@
 <Changes>
   <body>
     <release date="${buildTimestamp}" description="" version="2.0.0">
+      <action dev="Zachary Pedigo" issue="123" date="05-19-2024" type="fix">Fixed issue with current tab behavior.</action>
       <action dev="Zachary Pedigo" issue="121" date="05-19-2024" type="fix">Uplifted project to .NET 4.8.</action>
       <action dev="Zachary Pedigo" issue="111" date="09-16-2021" type="fix">Fixed file names associated with early development.</action>
       <action dev="Zachary Pedigo" issue="99" date="05-24-2021" type="add">Added right click menu.</action>


### PR DESCRIPTION
## Description 
* This code change resolves #123 

## Implementation Details 
* Instead of using the ActiveMDIChild property (which seems to have been changed since .NET 4.6.1), we can use the ActiveContent property of the dockPanel object created upon instantiation of the MainForm model. 
          