### PR TITLE
Fixed #153 control key stuck after saving

### DIFF
--- a/Notepad-Sharp.sln
+++ b/Notepad-Sharp.sln
@@ -10,20 +10,40 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Notepad-Sharp", "Notepad-Sh
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastColoredTextBox", "FastColoredTextBox\FastColoredTextBox\FastColoredTextBox.csproj", "{6DD14A85-CCFC-4774-BD26-0F5772512319}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tester", "FastColoredTextBox\Tester\Tester.csproj", "{EBE443EE-F4C7-49E6-AC22-959CA62FAA05}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2D886A7B-5A05-418E-8598-1E93D49321B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2D886A7B-5A05-418E-8598-1E93D49321B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2D886A7B-5A05-418E-8598-1E93D49321B5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2D886A7B-5A05-418E-8598-1E93D49321B5}.Debug|x86.Build.0 = Debug|Any CPU
 		{2D886A7B-5A05-418E-8598-1E93D49321B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2D886A7B-5A05-418E-8598-1E93D49321B5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2D886A7B-5A05-418E-8598-1E93D49321B5}.Release|x86.ActiveCfg = Release|Any CPU
+		{2D886A7B-5A05-418E-8598-1E93D49321B5}.Release|x86.Build.0 = Release|Any CPU
 		{6DD14A85-CCFC-4774-BD26-0F5772512319}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6DD14A85-CCFC-4774-BD26-0F5772512319}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6DD14A85-CCFC-4774-BD26-0F5772512319}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6DD14A85-CCFC-4774-BD26-0F5772512319}.Debug|x86.Build.0 = Debug|Any CPU
 		{6DD14A85-CCFC-4774-BD26-0F5772512319}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6DD14A85-CCFC-4774-BD26-0F5772512319}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6DD14A85-CCFC-4774-BD26-0F5772512319}.Release|x86.ActiveCfg = Release|Any CPU
+		{6DD14A85-CCFC-4774-BD26-0F5772512319}.Release|x86.Build.0 = Release|Any CPU
+		{EBE443EE-F4C7-49E6-AC22-959CA62FAA05}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{EBE443EE-F4C7-49E6-AC22-959CA62FAA05}.Debug|Any CPU.Build.0 = Debug|x86
+		{EBE443EE-F4C7-49E6-AC22-959CA62FAA05}.Debug|x86.ActiveCfg = Debug|x86
+		{EBE443EE-F4C7-49E6-AC22-959CA62FAA05}.Debug|x86.Build.0 = Debug|x86
+		{EBE443EE-F4C7-49E6-AC22-959CA62FAA05}.Release|Any CPU.ActiveCfg = Release|x86
+		{EBE443EE-F4C7-49E6-AC22-959CA62FAA05}.Release|Any CPU.Build.0 = Release|x86
+		{EBE443EE-F4C7-49E6-AC22-959CA62FAA05}.Release|x86.ActiveCfg = Release|x86
+		{EBE443EE-F4C7-49E6-AC22-959CA62FAA05}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Notepad-Sharp/MainForm.cs
+++ b/Notepad-Sharp/MainForm.cs
@@ -749,6 +749,7 @@ namespace NotepadSharp
                     if (CurrentTB != null)
                     {
                         CallSave(CurrentTB);
+                        CurrentTB.ResetModifierKeys();
                     }
                 }
                 else if (e.Control && e.Shift && e.KeyCode == Keys.L)

--- a/Notepad-Sharp/Windows/Editor.cs
+++ b/Notepad-Sharp/Windows/Editor.cs
@@ -202,6 +202,11 @@ namespace NotepadSharp.Windows
             }
         }
 
+        public void ResetModifierKeys()
+        {
+            mainEditor.ResetModifiers(null);
+        }
+
         public void ApplySettings()
         {
             this.mainEditor.Font = new Font(EditorSettings.Font.FontFamily.Name, EditorSettings.Font.Size);


### PR DESCRIPTION
### Description 
* Resolves #153 
* This change allows the previous modifier keys to be cleared properly after performing a hotkey action outside the scope of the FastColoredTextBox hotkeys. 