### PR TITLE
Patched issue with line and column count in status bar

### DIFF
--- a/Notepad-Sharp/MainForm.cs
+++ b/Notepad-Sharp/MainForm.cs
@@ -18,6 +18,16 @@ namespace NotepadSharp
     /// </summary>
     public partial class MainForm : Form
     {
+        #region Revision History
+
+        //----------------------------------------------------------------------------------
+        // Date        Engineer         Issue     Description
+        // ----------  --------------  ----   ----------------------------------------------
+        // 07/14/2025  Zachary Pedigo  188    Issue with line and column count in status bar
+        //----------------------------------------------------------------------------------
+
+        #endregion
+
         #region Variable declarations and definitions
 
         //Dialog definitions
@@ -1103,13 +1113,13 @@ namespace NotepadSharp
             }
         }
 
-        public void UpdateStatusBar()
+        void UpdateStatusBar()
         {
             linesStatusLabel.Text = "lines: " + CurrentTB?.mainEditor.LinesCount;
             string encodingText = CurrentTB?.mainEditor.Encoding?.HeaderName;
             encodingStatusLabel.Text = encodingText == null || encodingText == string.Empty ? "None" : encodingText;
-            currentLineStatusLabel.Text = "Ln: " + CurrentTB?.mainEditor.Selection.End.iLine.ToString();
-            columnStatusLabel.Text = "Col: " + CurrentTB?.mainEditor.Selection.End.iChar.ToString();
+            currentLineStatusLabel.Text = "Ln: " + CurrentTB?.LineCount.ToString();
+            columnStatusLabel.Text = "Col: " + CurrentTB?.ColumnCount.ToString();
         }
 
         #endregion

--- a/Notepad-Sharp/Windows/Editor.cs
+++ b/Notepad-Sharp/Windows/Editor.cs
@@ -12,6 +12,17 @@ namespace NotepadSharp.Windows
     /// </summary>
     public partial class Editor : DockContent
     {
+
+        #region Revision Log
+
+        //----------------------------------------------------------------------------------
+        // Date        Engineer         Issue     Description
+        // ----------  --------------  ----   ----------------------------------------------
+        // 07/14/2025  Zachary Pedigo  188    Added public member variables for current line and column count
+        //----------------------------------------------------------------------------------
+
+        #endregion
+
         private MainForm _parent;
         private string _syntaxLabelText;
         private bool _isUntitled;
@@ -71,13 +82,35 @@ namespace NotepadSharp.Windows
         }
 
         /// <summary>
-        /// The current language of the editor
+        /// The current language of the editor.
         /// </summary>
         public FastColoredTextBoxNS.Language Language
         {
             get
             {
                 return mainEditor.Language;
+            }
+        }
+
+        /// <summary>
+        /// The line number of the current position of the cursor.
+        /// </summary>
+        public int LineCount
+        {
+            get
+            {
+                return mainEditor.Selection.End.iLine + 1;
+            }
+        }
+
+        /// <summary>
+        /// The column of the current position of the cursor.
+        /// </summary>
+        public int ColumnCount
+        {
+            get
+            {
+                return mainEditor.Selection.End.iChar + 1;
             }
         }
 


### PR DESCRIPTION
### Description 
* This change patches an issue where the current line and column number in the status bar is behind by a value of 1. 
* This issue was resolved by moving that behavior into the Editor wrapper class that returns the integer value from the FCTB control and adds 1 to it. 

### Reason for adding public member variables 
* The reasoning behind adding those public member variables is to increase code readability as it hardly made sense to anybody but me why I was calling the end of a selection and what iLine and iChar was, so I moved it to some publicly accessible member variables inside the Editor wrapper and gave them names that made more sense. 